### PR TITLE
Path don't work on Linux beause of case sensitiveness (FIX)

### DIFF
--- a/files.qip
+++ b/files.qip
@@ -1,4 +1,4 @@
-set_global_assignment -name QIP_FILE T80/t80.qip
+set_global_assignment -name QIP_FILE T80/T80.qip
 set_global_assignment -name SYSTEMVERILOG_FILE sdram.sv
 set_global_assignment -name VHDL_FILE bram.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE YM2149.sv


### PR DESCRIPTION
There is a file T80/T80.qip that is referenced by the string 'T80/t80.qpi'.

This works on Windows, because its file system is case insensitive.

But fails on Linux.

This PR fixes that.